### PR TITLE
Relative/Absolute path resolution for import

### DIFF
--- a/docs/rules/import.md
+++ b/docs/rules/import.md
@@ -3,6 +3,7 @@
 ## Rule Details
 
 This rule allows you to forbid some module import and to suggest some alternative.
+You must supply the path to the file from the root. This prevents errors caused by having multiple files with the same name in different directories.
 
 ### Example:
 Let's consider we have this configuration in `.eslintrc`:
@@ -12,7 +13,7 @@ Let's consider we have this configuration in `.eslintrc`:
   "plugins": ["deprecate"],
   "rules": {
     "deprecate/import": ["error",
-      {"name": "legacyModule", "use": "newModule"}
+      {"name": "path/to/legacyModule", "use": "newModule"}
     ]
   }
 }
@@ -21,7 +22,11 @@ Let's consider we have this configuration in `.eslintrc`:
 ### The following patterns are considered as errors:
 
 ```js
-import a from 'legacyModule';
+import a from 'path/to/legacyModule'
+import a from '../../path/to/legacyModule'
+import a from 'legacyModule'
+const a = require('path/to/legacyModule');
+const a = require('../../path/to/legacyModule');
 const a = require('legacyModule');
 ```
 

--- a/lib/rules/import.js
+++ b/lib/rules/import.js
@@ -1,48 +1,48 @@
 const makeImportObj = (importName) => {
     if (typeof importName === 'string') {
-        return { name: importName }
+        return { name: importName };
     }
     if (typeof importName === 'object' && importName.name && importName.use) {
-        return importName
+        return importName;
     }
-    throw new Error(`Unsupported type of argument ${JSON.stringify(importName)}`)
-}
+    throw new Error(`Unsupported type of argument ${JSON.stringify(importName)}`);
+};
 
 const applyRelativeImportToCurrentFilepath = (filePath, importArray) => {
     // remove moduleName
-    let newPath = filePath.substr(filePath.lastIndexOf('/'))
-    importArray.forEach(segment => {
+    let newPath = filePath.substr(filePath.lastIndexOf('/'));
+    importArray.forEach((segment) => {
         if (segment === '..') {
-            newPath = newPath.substr(0, newPath.lastIndexOf('/'))
+            newPath = newPath.substr(0, newPath.lastIndexOf('/'));
         } else {
-            newPath = newPath.concat('/' + segment)
+            newPath = newPath.concat('/' + segment);
         }
-    })
-    return newPath
-}
+    });
+    return newPath;
+};
 
 const convertRelativePathToAbsolute = (currentFilename, currentImport) => {
-    const pathSegments = currentImport.split('/')
+    const pathSegments = currentImport.split('/');
     if (pathSegments.includes('..')) {
         //in relative path
-        const proposedAbsolutePath = applyRelativeImportToCurrentFilepath(currentFilename, pathSegments)
-        currentImport = proposedAbsolutePath
+        const proposedAbsolutePath = applyRelativeImportToCurrentFilepath(currentFilename, pathSegments);
+        currentImport = proposedAbsolutePath;
     }
 
-    const prefixesToDelete = ['/', './']
+    const prefixesToDelete = ['/', './'];
     prefixesToDelete.forEach(prefix => {
-        currentImport = currentImport.startsWith(prefix) ? currentImport.substring(prefix.length, currentImport.length) : currentImport
-    })
-    return currentImport
-}
+        currentImport = currentImport.startsWith(prefix) ? currentImport.substring(prefix.length, currentImport.length) : currentImport;
+    });
+    return currentImport;
+};
 
 const buildErrorMessage = (imp) => {
-    let errorMsg = `Module ${imp.name} is deprecated.`
+    let errorMsg = `Module ${imp.name} is deprecated.`;
     if (imp.use) {
-        errorMsg += ` Use ${imp.use} instead. `
+        errorMsg += ` Use ${imp.use} instead.`;
     }
-    return errorMsg
-}
+    return errorMsg;
+};
 
 module.exports = {
     meta: {
@@ -51,44 +51,44 @@ module.exports = {
         },
     },
     create(context) {
-        const imports = {}
+        const imports = {};
         context.options.map(makeImportObj).forEach((importObj) => {
-            imports[importObj.name] = importObj
+            imports[importObj.name] = importObj;
         })
 
         return {
             ImportDeclaration(node) {
-                const importPath = convertRelativePathToAbsolute(context.eslint.getFilename(), node.source.value)
+                const importPath = convertRelativePathToAbsolute(context.eslint.getFilename(), node.source.value);
 
-                let imp
+                let imp;
                 for(let importString in imports) {
-                    if(importString.includes(importPath)){
-                        imp = imports[importString]
-                        break
+                    if (importString.includes(importPath)) {
+                        imp = imports[importString];
+                        break;
                     }
                 }
 
                 if (!imp) {
-                    return
+                    return;
                 }
 
-                context.report({ node, message: buildErrorMessage(imp) })
+                context.report({ node, message: buildErrorMessage(imp)});
             },
             CallExpression(node) {
                 if (node.callee.name !== 'require' || !node.arguments.length) {
-                    return
+                    return;
                 }
-                const requireArg = node.arguments[0]
+                const requireArg = node.arguments[0];
                 if (requireArg.type !== 'Literal') {
-                    return
+                    return;
                 }
-                const imp = imports[requireArg.value]
+                const imp = imports[requireArg.value];
 
                 if (!imp) {
-                    return
+                    return;
                 }
-                context.report({ node, message: buildErrorMessage(imp) })
+                context.report({ node, message: buildErrorMessage(imp) });
             }
-        }
+        };
     }
-}
+};

--- a/lib/rules/import.js
+++ b/lib/rules/import.js
@@ -15,7 +15,7 @@ const applyRelativeImportToCurrentFilepath = (filePath, importArray) => {
         if (segment === '..') {
             newPath = newPath.substr(0, newPath.lastIndexOf('/'));
         } else {
-            newPath = newPath.concat('/' + segment);
+            newPath = newPath.concat(`/${segment}`);
         }
     });
     return newPath;
@@ -24,14 +24,16 @@ const applyRelativeImportToCurrentFilepath = (filePath, importArray) => {
 const convertRelativePathToAbsolute = (currentFilename, currentImport) => {
     const pathSegments = currentImport.split('/');
     if (pathSegments.includes('..')) {
-        //in relative path
+        // in relative path
         const proposedAbsolutePath = applyRelativeImportToCurrentFilepath(currentFilename, pathSegments);
         currentImport = proposedAbsolutePath;
     }
 
     const prefixesToDelete = ['/', './'];
-    prefixesToDelete.forEach(prefix => {
-        currentImport = currentImport.startsWith(prefix) ? currentImport.substring(prefix.length, currentImport.length) : currentImport;
+    prefixesToDelete.forEach((prefix) => {
+        currentImport = currentImport.startsWith(prefix) ?
+            currentImport.substring(prefix.length, currentImport.length) :
+            currentImport;
     });
     return currentImport;
 };
@@ -54,14 +56,14 @@ module.exports = {
         const imports = {};
         context.options.map(makeImportObj).forEach((importObj) => {
             imports[importObj.name] = importObj;
-        })
+        });
 
         return {
             ImportDeclaration(node) {
                 const importPath = convertRelativePathToAbsolute(context.eslint.getFilename(), node.source.value);
 
                 let imp;
-                for(let importString in imports) {
+                for (const importString in imports) { // eslint-disable-line no-restricted-syntax
                     if (importString.includes(importPath)) {
                         imp = imports[importString];
                         break;
@@ -72,7 +74,7 @@ module.exports = {
                     return;
                 }
 
-                context.report({ node, message: buildErrorMessage(imp)});
+                context.report({ node, message: buildErrorMessage(imp) });
             },
             CallExpression(node) {
                 if (node.callee.name !== 'require' || !node.arguments.length) {

--- a/lib/rules/import.js
+++ b/lib/rules/import.js
@@ -62,13 +62,12 @@ module.exports = {
             ImportDeclaration(node) {
                 const importPath = convertRelativePathToAbsolute(context.eslint.getFilename(), node.source.value);
 
-                let imp;
-                for (const importString in imports) { // eslint-disable-line no-restricted-syntax
-                    if (importString.includes(importPath)) {
-                        imp = imports[importString];
-                        break;
-                    }
-                }
+                if (!Object.entries(imports)) return;
+
+                const imp = Object.entries(imports)
+                    .filter(([importString]) => importString.includes(importPath))
+                    .map(([, value]) => value)
+                    .shift();
 
                 if (!imp) {
                     return;

--- a/lib/rules/import.js
+++ b/lib/rules/import.js
@@ -1,59 +1,94 @@
-function makeImportObj(importName) {
+const makeImportObj = (importName) => {
     if (typeof importName === 'string') {
-        return { name: importName };
+        return { name: importName }
     }
     if (typeof importName === 'object' && importName.name && importName.use) {
-        return importName;
+        return importName
     }
-    throw new Error(`Unsupported type of argument ${JSON.stringify(importName)}`);
+    throw new Error(`Unsupported type of argument ${JSON.stringify(importName)}`)
+}
+
+const applyRelativeImportToCurrentFilepath = (filePath, importArray) => {
+    // remove moduleName
+    let newPath = filePath.substr(filePath.lastIndexOf('/'))
+    importArray.forEach(segment => {
+        if (segment === '..') {
+            newPath = newPath.substr(0, newPath.lastIndexOf('/'))
+        } else {
+            newPath = newPath.concat('/' + segment)
+        }
+    })
+    return newPath
+}
+
+const convertRelativePathToAbsolute = (currentFilename, currentImport) => {
+    const pathSegments = currentImport.split('/')
+    if (pathSegments.includes('..')) {
+        //in relative path
+        const proposedAbsolutePath = applyRelativeImportToCurrentFilepath(currentFilename, pathSegments)
+        currentImport = proposedAbsolutePath
+    }
+
+    const prefixesToDelete = ['/', './']
+    prefixesToDelete.forEach(prefix => {
+        currentImport = currentImport.startsWith(prefix) ? currentImport.substring(prefix.length, currentImport.length) : currentImport
+    })
+    return currentImport
+}
+
+const buildErrorMessage = (imp) => {
+    let errorMsg = `Module ${imp.name} is deprecated.`
+    if (imp.use) {
+        errorMsg += ` Use ${imp.use} instead. `
+    }
+    return errorMsg
 }
 
 module.exports = {
     meta: {
         docs: {
-            description: 'forbid some func names'
+            description: 'Forbids importing from given files.'
         },
     },
     create(context) {
-        const imports = {};
+        const imports = {}
         context.options.map(makeImportObj).forEach((importObj) => {
-            imports[importObj.name] = importObj;
-        });
+            imports[importObj.name] = importObj
+        })
 
         return {
             ImportDeclaration(node) {
-                const imp = imports[node.source.value];
+                const importPath = convertRelativePathToAbsolute(context.eslint.getFilename(), node.source.value)
+
+                let imp
+                for(let importString in imports) {
+                    if(importString.includes(importPath)){
+                        imp = imports[importString]
+                        break
+                    }
+                }
+
                 if (!imp) {
-                    return;
+                    return
                 }
-                let errorMsg = `Module ${imp.name} is deprecated.`;
-                if (imp.use) {
-                    errorMsg += ` Use ${imp.use} instead`;
-                }
-                context.report({ node, message: errorMsg });
+
+                context.report({ node, message: buildErrorMessage(imp) })
             },
             CallExpression(node) {
                 if (node.callee.name !== 'require' || !node.arguments.length) {
-                    return;
+                    return
                 }
-                const requireArg = node.arguments[0];
+                const requireArg = node.arguments[0]
                 if (requireArg.type !== 'Literal') {
-                    return;
+                    return
                 }
-                const imp = imports[requireArg.value];
+                const imp = imports[requireArg.value]
 
                 if (!imp) {
-                    return;
+                    return
                 }
-
-                let errorMsg = `Module ${imp.name} is deprecated.`;
-
-                if (imp.use) {
-                    errorMsg += ` Use ${imp.use} instead`;
-                }
-                context.report({ node, message: errorMsg });
+                context.report({ node, message: buildErrorMessage(imp) })
             }
-        };
+        }
     }
-};
-
+}

--- a/lib/rules/import.js
+++ b/lib/rules/import.js
@@ -8,7 +8,7 @@ const makeImportObj = (importName) => {
     throw new Error(`Unsupported type of argument ${JSON.stringify(importName)}`);
 };
 
-const applyRelativeImportToCurrentFilepath = (filePath, importArray) => {
+const convertRelativePathToAbsolute = (filePath, importArray) => {
     // remove moduleName
     let newPath = filePath.substr(filePath.lastIndexOf('/'));
     importArray.forEach((segment) => {
@@ -21,11 +21,11 @@ const applyRelativeImportToCurrentFilepath = (filePath, importArray) => {
     return newPath;
 };
 
-const convertRelativePathToAbsolute = (currentFilename, currentImport) => {
+const conditionallyFormatFilePath = (currentFilename, currentImport) => {
     const pathSegments = currentImport.split('/');
     if (pathSegments.includes('..')) {
         // in relative path
-        const proposedAbsolutePath = applyRelativeImportToCurrentFilepath(currentFilename, pathSegments);
+        const proposedAbsolutePath = convertRelativePathToAbsolute(currentFilename, pathSegments);
         currentImport = proposedAbsolutePath;
     }
 
@@ -60,7 +60,7 @@ module.exports = {
 
         return {
             ImportDeclaration(node) {
-                const importPath = convertRelativePathToAbsolute(context.eslint.getFilename(), node.source.value);
+                const importPath = conditionallyFormatFilePath(context.eslint.getFilename(), node.source.value);
 
                 if (!Object.entries(imports)) return;
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/index.js",
   "scripts": {
-    "test": "mocha --compilers js:babel-register --recursive tests/rules/test_member_expression.js",
+    "test": "mocha --compilers js:babel-register --recursive tests/**/*.js",
     "build": "babel lib --out-dir dist",
     "lint": "eslint lib tests",
     "fix": "eslint --fix lib tests",

--- a/tests/rules/test_import.js
+++ b/tests/rules/test_import.js
@@ -16,6 +16,11 @@ ruleTester.run('import', rule, {
             code: 'const a = require("Module")',
             parser: 'babel-eslint',
             options: ['Legacy'],
+        },
+        {
+            code: 'const a = require("Module")',
+            parser: 'babel-eslint',
+            options: ['path/to/Legacy'],
         }
     ],
     invalid: [
@@ -32,7 +37,31 @@ ruleTester.run('import', rule, {
             parser: 'babel-eslint',
             options: [{ name: 'Legacy', use: 'New' }],
             errors: [{
-                message: 'Module Legacy is deprecated. Use New instead'
+                message: 'Module Legacy is deprecated. Use New instead.'
+            }]
+        },
+        {
+            code: 'import a from "Legacy"',
+            parser: 'babel-eslint',
+            options: [{ name: 'path/to/Legacy', use: 'New' }],
+            errors: [{
+                message: 'Module path/to/Legacy is deprecated. Use New instead.'
+            }]
+        },
+        {
+            code: 'import a from "path/to/Legacy"',
+            parser: 'babel-eslint',
+            options: [{ name: 'path/to/Legacy', use: 'New' }],
+            errors: [{
+                message: 'Module path/to/Legacy is deprecated. Use New instead.'
+            }]
+        },
+        {
+            code: 'import a from "../../Legacy"',
+            parser: 'babel-eslint',
+            options: [{ name: 'path/to/Legacy', use: 'New' }],
+            errors: [{
+                message: 'Module path/to/Legacy is deprecated. Use New instead.'
             }]
         },
         {
@@ -46,7 +75,7 @@ ruleTester.run('import', rule, {
             code: 'var a = require("Legacy")',
             options: [{ name: 'Legacy', use: 'New' }],
             errors: [{
-                message: 'Module Legacy is deprecated. Use New instead'
+                message: 'Module Legacy is deprecated. Use New instead.'
             }]
         },
     ]


### PR DESCRIPTION
This PR adds the ability for the plugin to find imports pulled in via relative paths (../../path/to/file) as well as any substring of the absolute path. It is not a breaking change, but users should be advised to include the full path to the deprecated file in .eslintrc to enable these new features.