### PR TITLE
Fix deprecate/import rule error

### DIFF
--- a/lib/rules/import.js
+++ b/lib/rules/import.js
@@ -60,7 +60,8 @@ module.exports = {
 
         return {
             ImportDeclaration(node) {
-                const importPath = conditionallyFormatFilePath(context.eslint.getFilename(), node.source.value);
+                const filename = context.eslint ? context.eslint.getFilename() : context.getFilename();
+                const importPath = conditionallyFormatFilePath(filename, node.source.value);
 
                 if (!Object.entries(imports)) return;
 


### PR DESCRIPTION
The `deprecate/import` rule is broken for me in version 0.5.1. Whenever I run eslint, I get an error: 

```
TypeError: Cannot read property 'getFilename' of undefined
    at ImportDeclaration (/path/to/project/node_modules/eslint-plugin-deprecate/dist/rules/import.js:67:76)
```

This fix may not be correct, but I'm able to get it working by changing `context.eslint.getFilename() ` to `context.getFilename()`