### PR TITLE
Fix import rule

### DIFF
--- a/lib/rules/import.js
+++ b/lib/rules/import.js
@@ -66,7 +66,7 @@ module.exports = {
                 if (!Object.entries(imports)) return;
 
                 const imp = Object.entries(imports)
-                    .filter(([importString]) => importString.includes(importPath))
+                    .filter(([importString]) => importPath.includes(importString))
                     .map(([, value]) => value)
                     .shift();
 

--- a/tests/rules/test_import.js
+++ b/tests/rules/test_import.js
@@ -43,49 +43,39 @@ ruleTester.run('import', rule, {
             code: 'import a from "Legacy"',
             parser: 'babel-eslint',
             options: ['Legacy'],
-            errors: [
-                {
-                    message: 'Module Legacy is deprecated.'
-                }
-            ]
+            errors: [{
+                message: 'Module Legacy is deprecated.'
+            }]
         },
         {
             code: 'import a from "Legacy"',
             parser: 'babel-eslint',
             options: [{ name: 'Legacy', use: 'New' }],
-            errors: [
-                {
-                    message: 'Module Legacy is deprecated. Use New instead.'
-                }
-            ]
+            errors: [{
+                message: 'Module Legacy is deprecated. Use New instead.'
+            }]
         },
         {
             code: 'import a from "path/to/Legacy"',
             parser: 'babel-eslint',
             options: [{ name: 'path/to/Legacy', use: 'New' }],
-            errors: [
-                {
-                    message: 'Module path/to/Legacy is deprecated. Use New instead.'
-                }
-            ]
+            errors: [{
+                message: 'Module path/to/Legacy is deprecated. Use New instead.'
+            }]
         },
         {
             code: 'var a = require("Legacy")',
             options: ['Legacy'],
-            errors: [
-                {
-                    message: 'Module Legacy is deprecated.'
-                }
-            ]
+            errors: [{
+                message: 'Module Legacy is deprecated.'
+            }]
         },
         {
             code: 'var a = require("Legacy")',
             options: [{ name: 'Legacy', use: 'New' }],
-            errors: [
-                {
-                    message: 'Module Legacy is deprecated. Use New instead.'
-                }
-            ]
+            errors: [{
+                message: 'Module Legacy is deprecated. Use New instead.'
+            }]
         }
     ]
 });

--- a/tests/rules/test_import.js
+++ b/tests/rules/test_import.js
@@ -10,32 +10,32 @@ ruleTester.run('import', rule, {
         {
             code: 'import a from "Module"',
             parser: 'babel-eslint',
-            options: ['Legacy']
+            options: ['Legacy'],
         },
         {
             code: 'const a = require("Module")',
             parser: 'babel-eslint',
-            options: ['Legacy']
+            options: ['Legacy'],
         },
         {
             code: 'const a = require("Module")',
             parser: 'babel-eslint',
-            options: ['path/to/Legacy']
+            options: ['path/to/Legacy'],
         },
         {
             code: 'import a from "../../Legacy"',
             parser: 'babel-eslint',
-            options: [{ name: 'path/to/Legacy', use: 'New' }]
+            options: [{ name: 'path/to/Legacy', use: 'New' }],
         },
         {
             code: 'import a from "Legacy"',
             parser: 'babel-eslint',
-            options: [{ name: 'path/to/Legacy', use: 'New' }]
+            options: [{ name: 'path/to/Legacy', use: 'New' }],
         },
         {
             code: 'import a from "path/to"',
             parser: 'babel-eslint',
-            options: [{ name: 'path/to/legacy', use: 'New' }]
+            options: [{ name: 'path/to/legacy', use: 'New' }],
         }
     ],
     invalid: [

--- a/tests/rules/test_import.js
+++ b/tests/rules/test_import.js
@@ -40,6 +40,14 @@ ruleTester.run('import', rule, {
     ],
     invalid: [
         {
+            code: 'import a from "root/deprecated/path/to/legacy"',
+            parser: 'babel-eslint',
+            options: ['root/deprecated'],
+            errors: [{
+                message: 'Module root/deprecated is deprecated.'
+            }]
+        },
+        {
             code: 'import a from "Legacy"',
             parser: 'babel-eslint',
             options: ['Legacy'],
@@ -76,6 +84,6 @@ ruleTester.run('import', rule, {
             errors: [{
                 message: 'Module Legacy is deprecated. Use New instead.'
             }]
-        }
+        },
     ]
 });

--- a/tests/rules/test_import.js
+++ b/tests/rules/test_import.js
@@ -10,17 +10,32 @@ ruleTester.run('import', rule, {
         {
             code: 'import a from "Module"',
             parser: 'babel-eslint',
-            options: ['Legacy'],
+            options: ['Legacy']
         },
         {
             code: 'const a = require("Module")',
             parser: 'babel-eslint',
-            options: ['Legacy'],
+            options: ['Legacy']
         },
         {
             code: 'const a = require("Module")',
             parser: 'babel-eslint',
-            options: ['path/to/Legacy'],
+            options: ['path/to/Legacy']
+        },
+        {
+            code: 'import a from "../../Legacy"',
+            parser: 'babel-eslint',
+            options: [{ name: 'path/to/Legacy', use: 'New' }]
+        },
+        {
+            code: 'import a from "Legacy"',
+            parser: 'babel-eslint',
+            options: [{ name: 'path/to/Legacy', use: 'New' }]
+        },
+        {
+            code: 'import a from "path/to"',
+            parser: 'babel-eslint',
+            options: [{ name: 'path/to/legacy', use: 'New' }]
         }
     ],
     invalid: [
@@ -28,55 +43,49 @@ ruleTester.run('import', rule, {
             code: 'import a from "Legacy"',
             parser: 'babel-eslint',
             options: ['Legacy'],
-            errors: [{
-                message: 'Module Legacy is deprecated.'
-            }]
+            errors: [
+                {
+                    message: 'Module Legacy is deprecated.'
+                }
+            ]
         },
         {
             code: 'import a from "Legacy"',
             parser: 'babel-eslint',
             options: [{ name: 'Legacy', use: 'New' }],
-            errors: [{
-                message: 'Module Legacy is deprecated. Use New instead.'
-            }]
-        },
-        {
-            code: 'import a from "Legacy"',
-            parser: 'babel-eslint',
-            options: [{ name: 'path/to/Legacy', use: 'New' }],
-            errors: [{
-                message: 'Module path/to/Legacy is deprecated. Use New instead.'
-            }]
+            errors: [
+                {
+                    message: 'Module Legacy is deprecated. Use New instead.'
+                }
+            ]
         },
         {
             code: 'import a from "path/to/Legacy"',
             parser: 'babel-eslint',
             options: [{ name: 'path/to/Legacy', use: 'New' }],
-            errors: [{
-                message: 'Module path/to/Legacy is deprecated. Use New instead.'
-            }]
-        },
-        {
-            code: 'import a from "../../Legacy"',
-            parser: 'babel-eslint',
-            options: [{ name: 'path/to/Legacy', use: 'New' }],
-            errors: [{
-                message: 'Module path/to/Legacy is deprecated. Use New instead.'
-            }]
+            errors: [
+                {
+                    message: 'Module path/to/Legacy is deprecated. Use New instead.'
+                }
+            ]
         },
         {
             code: 'var a = require("Legacy")',
             options: ['Legacy'],
-            errors: [{
-                message: 'Module Legacy is deprecated.'
-            }]
+            errors: [
+                {
+                    message: 'Module Legacy is deprecated.'
+                }
+            ]
         },
         {
             code: 'var a = require("Legacy")',
             options: [{ name: 'Legacy', use: 'New' }],
-            errors: [{
-                message: 'Module Legacy is deprecated. Use New instead.'
-            }]
-        },
+            errors: [
+                {
+                    message: 'Module Legacy is deprecated. Use New instead.'
+                }
+            ]
+        }
     ]
 });


### PR DESCRIPTION
fixes #9.

I.e. `path/to/legacy` rule should allow other `path/to` imports, while 
`root/legacy` rule should forbid whole `root/legacy/**/*` directory.