### PR TITLE
Fix import rule "cannot read property of undefined"

### DIFF
--- a/lib/rules/import.js
+++ b/lib/rules/import.js
@@ -38,6 +38,9 @@ module.exports = {
                     });
             },
             MemberExpression(node) {
+                if (!node.object.callee) {
+                    return
+                }
                 if ((node.object.callee.name !== 'require' || !node.object.arguments.length) && !node.property) {
                     return;
                 }
@@ -58,8 +61,8 @@ module.exports = {
                 const childNode = node.declarations[0];
                 if (!(childNode.id && childNode.id.type === 'ObjectPattern' && childNode.init)) return;
 
-                const requireArg = childNode.init.arguments[0];
-                if (requireArg.type !== 'Literal' || childNode.init.callee.name !== 'require') {
+                const requireArg = childNode.init.arguments && childNode.init.arguments[0];
+                if (!requireArg || requireArg.type !== 'Literal' || childNode.init.callee.name !== 'require') {
                     return;
                 }
 


### PR DESCRIPTION
fixes #28 

rules/import add null checks to fix error when trying to read property of undefined

all tests are passing

<img width="407" alt="image" src="https://github.com/AlexMost/eslint-plugin-deprecate/assets/3171352/06e264ba-ce84-4f99-ba62-9682495ac9cf">
