### PR TITLE
fix imports that were causing thrown errors

### DIFF
--- a/lib/ImportChecker.js
+++ b/lib/ImportChecker.js
@@ -27,6 +27,9 @@ class ImportChecker {
             return importPath === this.name;
         }
         if (this.regExp) {
+            if (typeof importPath !== 'string') {
+                return false
+            }
             return Boolean(importPath.match(this.regExp));
         }
         throw new Error('You should provide "name" or "nameRegExp" as an option to plugin');

--- a/lib/rules/import.js
+++ b/lib/rules/import.js
@@ -45,7 +45,7 @@ module.exports = {
                     return;
                 }
                 const requireArg = node.object.arguments[0];
-                if (requireArg.type !== 'Literal') {
+                if (requireArg && requireArg.type !== 'Literal') {
                     return;
                 }
                 const propertyNameSet = new Set([node.property.name]);


### PR DESCRIPTION
After my previous fix for the import rule I ran it on a large codebase and found a few more issues that pop up. I'm not sure what's causing these to happen but adding safety checks fixed it and all tests are still passing.