### PR TITLE
fix: check if requireArg is undefined

### DIFF
--- a/lib/rules/import.js
+++ b/lib/rules/import.js
@@ -45,7 +45,7 @@ module.exports = {
                     return;
                 }
                 const requireArg = node.object.arguments[0];
-                if (requireArg.type !== 'Literal') {
+                if (!requireArg || requireArg.type !== 'Literal') {
                     return;
                 }
                 const propertyNameSet = new Set([node.property.name]);


### PR DESCRIPTION
Resolves attempt to read type causing: `TypeError: Cannot read properties of undefined (reading 'type')`

All tests pass:
![image](https://github.com/AlexMost/eslint-plugin-deprecate/assets/6650168/b2f7af3e-e4de-4665-8a7d-73c397c202db)
