### PR TITLE
Declare all options for rule `import`

### DIFF
--- a/lib/rules/import.js
+++ b/lib/rules/import.js
@@ -5,6 +5,37 @@ module.exports = {
         docs: {
             description: 'Forbids importing from given files.'
         },
+        schema: {
+            type: "array",
+            items: [
+                {
+                    anyOf: [{
+                        type: "object",
+                        properties: {
+                            name: {
+                                type: "string",
+                                minLength: 1,
+                            },
+                            use: {
+                                type: "string",
+                                minLength: 1,
+                            },
+                            nameRegExp: {
+                                type: "string",
+                                minLength: 1,
+                            },
+                            module: {
+                                type: "string",
+                                minLength: 1,
+                            }
+                        },
+                        additionalProperties: false
+                    }, {
+                        type: "string"
+                    }]
+                }
+            ]
+        }
     },
     create(context) {
         const imports = context.options.map((opt) => new ImportChecker(opt));


### PR DESCRIPTION
[x] Tested with several options available

# Why
It's better for LintLens extension in VSCode (no more LintLens error)