### PR TITLE
Feat: Opt out validate context.options to can run plugin in eslint v9

### DIFF
--- a/lib/rules/function.js
+++ b/lib/rules/function.js
@@ -13,6 +13,7 @@ module.exports = {
         docs: {
             description: 'forbid some func names'
         },
+        schema: false,
     },
     create(context) {
         const funcs = {};

--- a/lib/rules/import.js
+++ b/lib/rules/import.js
@@ -5,6 +5,7 @@ module.exports = {
         docs: {
             description: 'Forbids importing from given files.'
         },
+        schema: false,
     },
     create(context) {
         const imports = context.options.map((opt) => new ImportChecker(opt));

--- a/lib/rules/member-expression.js
+++ b/lib/rules/member-expression.js
@@ -13,6 +13,7 @@ module.exports = {
         docs: {
             description: 'forbid some func names'
         },
+        schema: false,
     },
     create(context) {
         const memberStrMap = {};


### PR DESCRIPTION
# Motivation
I want to use this plugin with ESLint v9, when I upgrade ESLint v9, I caught some issues and after investigate I recognized we need to opt out validate `context.options`.

# Changes
Set `schema: false` in `meta` object to opt out validate `context.options`

# Refference
[Options Schema](https://eslint.org/docs/latest/extend/custom-rules#options-schemas)